### PR TITLE
Update requirements.txt to fix invalid langchain URL

### DIFF
--- a/app-comparison.py
+++ b/app-comparison.py
@@ -5,7 +5,6 @@ import os
 # Import depdencies 
 from langchain.llms import GPT4All, OpenAI
 from langchain import PromptTemplate, LLMChain
-from ctransformers.langchain import CTransformers
 
 # Python toolchain imports 
 from langchain.agents.agent_toolkits import create_python_agent

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ Jinja2==3.1.2
 jsonschema==4.17.3
 jupyter_client==8.2.0
 jupyter_core==5.3.0
-langchain @ git+https://github.com/Chae4ek/langchain.git@5e4a057349e2608903a0a836041801729a4465a1
+langchain @ git+https://github.com/hwchase17/langchain.git@5e4a057349e2608903a0a836041801729a4465a1
 markdown-it-py==2.2.0
 MarkupSafe==2.1.2
 marshmallow==3.19.0


### PR DESCRIPTION
I am getting this error when installing requirement.
```
PS C:\Nopenai> pip install -r requirements.txt
Collecting langchain@ git+https://github.com/Chae4ek/langchain.git@5e4a057349e2608903a0a836041801729a4465a1 (from -r requirements.txt (line 37))
  Cloning https://github.com/Chae4ek/langchain.git (to revision 5e4a057349e2608903a0a836041801729a4465a1) to c:\users\ noone\appdata\local\temp\pip-install-xg2696hq\langchain_7c41d5f72ba2410db653295037ac0fe5
  Running command git clone --filter=blob:none --quiet https://github.com/Chae4ek/langchain.git 'C:\Users\ noone\AppData\Local\Temp\pip-install-xg2696hq\langchain_7c41d5f72ba2410db653295037ac0fe5'
  remote: Repository not found.
  fatal: repository 'https://github.com/Chae4ek/langchain.git/' not found
  error: subprocess-exited-with-error
  
  × git clone --filter=blob:none --quiet https://github.com/Chae4ek/langchain.git 'C:\Users\ noone\AppData\Local\Temp\pip-install-xg2696hq\langchain_7c41d5f72ba2410db653295037ac0fe5' did not run successfully.
  │ exit code: 128
  ╰─> See above for output.
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× git clone --filter=blob:none --quiet https://github.com/Chae4ek/langchain.git 'C:\Users\ noone\AppData\Local\Temp\pip-install-xg2696hq\langchain_7c41d5f72ba2410db653295037ac0fe5' did not run successfully.
│ exit code: 128
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```

The langchain package references a URL (https://github.com/Chae4ek/langchain) that returns a 404 error.

To fix this issue, I have updated the URL in the requirements.txt file to a valid one (https://github.com/hwchase17/langchain).
